### PR TITLE
Fix scalacOptions not being set to the right values

### DIFF
--- a/core/src/main/scala/kantan/sbt/KantanPlugin.scala
+++ b/core/src/main/scala/kantan/sbt/KantanPlugin.scala
@@ -112,7 +112,7 @@ object KantanPlugin extends AutoPlugin {
     Seq(
       // If we're running 2.12+, compile to 1.8 bytecode. Otherwise, 1.6.
       javacOptions := {
-        val jvm = (CrossVersion.partialVersion(version.value) match {
+        val jvm = (CrossVersion.partialVersion(scalaVersion.value) match {
           case Some((maj, min)) if maj > 2 || min >= 12 ⇒ "1.8"
           case _                                        ⇒ "1.6"
         })

--- a/core/src/sbt-test/core/java6/build.sbt
+++ b/core/src/sbt-test/core/java6/build.sbt
@@ -1,0 +1,10 @@
+scalaVersion := "2.11.12"
+
+lazy val check = TaskKey[Unit]("check")
+
+check := {
+  val options = javacOptions.value.mkString(" ")
+
+  if(!(options.contains("-source 1.6") && options.contains("-target 1.6")))
+    sys.error(s"Expected source and target to be 1.6, but javacOptions are ${options}")
+}

--- a/core/src/sbt-test/core/java6/project/build.properties
+++ b/core/src/sbt-test/core/java6/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.2.8

--- a/core/src/sbt-test/core/java6/project/plugins.sbt
+++ b/core/src/sbt-test/core/java6/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.nrinaudo" % "kantan.sbt" % sys.props("plugin.version"))

--- a/core/src/sbt-test/core/java6/test
+++ b/core/src/sbt-test/core/java6/test
@@ -1,0 +1,2 @@
+# Make sure javacOptions contains the expected values
+> check

--- a/core/src/sbt-test/core/java8/build.sbt
+++ b/core/src/sbt-test/core/java8/build.sbt
@@ -1,0 +1,10 @@
+scalaVersion := "2.12.8"
+
+lazy val check = TaskKey[Unit]("check")
+
+check := {
+  val options = javacOptions.value.mkString(" ")
+
+  if(!(options.contains("-source 1.8") && options.contains("-target 1.8")))
+    sys.error(s"Expected source and target to be 1.8, but javacOptions are ${options}")
+}

--- a/core/src/sbt-test/core/java8/project/build.properties
+++ b/core/src/sbt-test/core/java8/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.2.8

--- a/core/src/sbt-test/core/java8/project/plugins.sbt
+++ b/core/src/sbt-test/core/java8/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.nrinaudo" % "kantan.sbt" % sys.props("plugin.version"))

--- a/core/src/sbt-test/core/java8/test
+++ b/core/src/sbt-test/core/java8/test
@@ -1,0 +1,2 @@
+# Make sure javacOptions contains the expected values
+> check


### PR DESCRIPTION
The heuristics used to decide whether to target 1.6 or 1.8 based itself on the version of kantan.sbt, not of scala...