### PR TITLE
Update Scala.js to 1.x (and dropping 0.6.x)

### DIFF
--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -10,7 +10,7 @@ object Versions {
   val sbtSite: String      = "1.4.0"
   val sbtSonatype: String  = "3.9.2"
   val sbtUnidoc: String    = "0.4.3"
-  val scalajs: String      = Option(System.getenv("SCALAJS_VERSION")).filter(_.nonEmpty).getOrElse("1.1.0")
+  val scalajs: String      = "1.1.0"
   val scalajsCross: String = "0.6.1"
   val scalastyle: String   = "1.0.0"
   val scoverage: String    = "1.6.1"

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -10,7 +10,7 @@ object Versions {
   val sbtSite: String      = "1.4.0"
   val sbtSonatype: String  = "3.9.2"
   val sbtUnidoc: String    = "0.4.3"
-  val scalajs: String      = "0.6.32"
+  val scalajs: String      = Option(System.getenv("SCALAJS_VERSION")).filter(_.nonEmpty).getOrElse("1.1.0")
   val scalajsCross: String = "0.6.1"
   val scalastyle: String   = "1.0.0"
   val scoverage: String    = "1.6.1"


### PR DESCRIPTION
Addresses https://github.com/nrinaudo/kantan.csv/issues/220

I think that use-site (kantab.sbt, e.g.) can cross-build by defining `SCALAJS_VERSION` environment variable, if cross-build is required.
This pattern is commonly used in Scala.js ecosystem.
