### PR TITLE
Fix version

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.6.1-SNAPSHOT"
+version in ThisBuild := "2.7.1-SNAPSHOT"


### PR DESCRIPTION
I've messed something, not sure what, not sure when, but the current
dev version was 2.6.1-SNAPSHOT while the current release version was
2.7.0.

This commit brings both in sync.