### PR TITLE
Add Scala 3 support

### DIFF
--- a/core/src/main/scala/kantan/sbt/KantanPlugin.scala
+++ b/core/src/main/scala/kantan/sbt/KantanPlugin.scala
@@ -201,6 +201,22 @@ object KantanPlugin extends AutoPlugin {
 //          "-Xsource:2.14", // Disabled for the moment, it doesn't work quite right yet
           "-Xlint:inaccessible"
         )
+      case Some((3, _)) =>
+        Seq(
+          "-deprecation", // Emit warning and location for usages of deprecated APIs.
+          "-encoding",
+          "utf-8",                         // Specify character encoding used by source files.
+          "-explain-types",                // Explain type errors in more detail.
+          "-feature",                      // Emit warning and location for usages of features that should be imported explicitly.
+          "-language:existentials",        // Existential types (besides wildcard types) can be written and inferred
+          "-language:experimental.macros", // Allow macro definition (besides implementation and application)
+          "-language:higherKinds",         // Allow higher-kinded types
+          "-language:implicitConversions", // Allow definition of implicit functions called views
+          "-unchecked",                    // Enable additional warnings where generated code depends on assumptions.
+          "-Xlint:private-shadow",         // A private field (or class parameter) shadows a superclass field.
+          "-Xlint:type-parameter-shadow",  // A local type parameter shadows a type already in scope.
+          "-Ysafe-init",                   // Wrap field accessors to throw an exception on uninitialized access..
+        )
       // otherwise fail
       case v => sys.error(s"Unknown Scala version: $v")
     }

--- a/kantan/src/main/scala/kantan/sbt/kantan/KantanKantanPlugin.scala
+++ b/kantan/src/main/scala/kantan/sbt/kantan/KantanKantanPlugin.scala
@@ -52,7 +52,7 @@ object KantanKantanPlugin extends AutoPlugin {
     organization         := "com.nrinaudo",
     organizationHomepage := Some(url("https://nrinaudo.github.io")),
     organizationName     := "Nicolas Rinaudo",
-    crossScalaVersions   := Seq("2.12.15", "2.13.8"),
+    crossScalaVersions   := Seq("2.12.15", "2.13.8", "3.3.4"),
     scalaVersion         := crossScalaVersions.value.last,
     licenses             := Seq("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0.html")),
     scalastyleResource   := Some("/kantan/sbt/scalastyle-config.xml"),


### PR DESCRIPTION
Hello @nrinaudo! I started my work on Scala 3 support in kantan.xpath as I suggested [here](https://github.com/nrinaudo/kantan.xpath/issues/158). In order to do that I added Scala 3 support to kantan.sbt. Scalac flags are tested and work fine with Scala 3.3.4. Please, take a look and publish new kantan.sbt revision. Thanks!